### PR TITLE
(QENG-3515) Update nexus to 2.12.1

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,7 @@
 class nexus (
   $source  = 'http://buildsources.delivery.puppetlabs.net/tools/',
   $dest    = '/var/www',
-  $version = '2.12.0-01',
+  $version = '2.12.1-01',
   $port    = '8081',
 ) {
   $source_url = "${source}/nexus-${version}-bundle.tar.gz"


### PR DESCRIPTION
Really fix the rubygems/bundler issue this time (https://issues.sonatype.org/browse/NEXUS-9551)
