### PR TITLE
(OPS-8460) Do not recursively manage the destination

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,8 +18,7 @@ class nexus (
   }
 
   file { $dest:
-    ensure  => 'directory',
-    recurse => 'true'
+    ensure  => 'directory'
   }
 
   exec { 'nexus-download':


### PR DESCRIPTION
Recursively managing the destination directory can be a significant impact once there are a lot of files there. As this doesn't actually do anything with the tree, other than the stated destination dir, remove the recursive parameter.
